### PR TITLE
exit 1 instead of return

### DIFF
--- a/harpoon.kak
+++ b/harpoon.kak
@@ -8,7 +8,7 @@ define-command harpoon-add -docstring "harpoon-add: Add the current file to the 
       index=$(($index + 1))
       if [ "$1" = "$kak_bufname" ]; then
         echo "fail %{$kak_quoted_bufname is already harpooned at index $index}"
-        return
+        exit 1
       fi
       shift
     done


### PR DESCRIPTION
This fixes following shell error occuring in *debug* buffer:
shell stderr: <<<sh: line 8: return: can only `return' from a function or sourced script>>>